### PR TITLE
Fix augmentation research cannot be completed by making it automatically unlocked

### DIFF
--- a/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
+++ b/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
@@ -24,7 +24,7 @@ public class Compat {
         Thaumcraft.registerRecipes();
         AspectList al = new AspectList().add(Aspect.TOOL, 20).add(Aspect.MAGIC, 20);
         new ResearchItem("TINKERSAUGUMENTATION", "ARTIFICE", al, 7, 6, 7, new ItemStack(TinkerTools.titleIcon, 1, 4099))
-                .setPages(new ResearchPage("By using your infusion matrix you were able to add an additional modifier to your TConstruct Tools. Sadly the matrix is only capable of doing this once per tool."),
+                .setPages(new ResearchPage("STiC"),
                         new ResearchPage(Thaumcraft.infusion))
                 .setAutoUnlock()
                 .registerResearchItem();

--- a/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
+++ b/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
@@ -23,7 +23,7 @@ public class Compat {
     public static void thaumic() {
         Thaumcraft.registerRecipes();
         AspectList al = new AspectList().add(Aspect.TOOL, 20).add(Aspect.MAGIC, 20);
-        new ResearchItem("TINKERSAUGUMENTATION", "ARTIFICE", al, 7, 6, 7, new ItemStack(TinkerTools.titleIcon, 1, 4099))
+        new ResearchItem("TINKERSAUGMENTATION", "ARTIFICE", al, 7, 6, 7, new ItemStack(TinkerTools.titleIcon, 1, 4099))
                 .setPages(new ResearchPage("STiC"),
                         new ResearchPage(Thaumcraft.infusion))
                 .setAutoUnlock()

--- a/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
+++ b/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
@@ -26,9 +26,7 @@ public class Compat {
         new ResearchItem("TINKERSAUGUMENTATION", "ARTIFICE", al, 7, 6, 7, new ItemStack(TinkerTools.titleIcon, 1, 4099))
                 .setPages(new ResearchPage("By using your infusion matrix you were able to add an additional modifier to your TConstruct Tools. Sadly the matrix is only capable of doing this once per tool."),
                         new ResearchPage(Thaumcraft.infusion))
-                .setParents("RUNICAUGMENTATION")
-                .setSpecial()
-                .setHidden()
+                .setAutoUnlock();
                 .registerResearchItem();
     }
 

--- a/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
+++ b/src/main/java/com/Zoko061602/SuperTic/compat/Compat.java
@@ -26,7 +26,7 @@ public class Compat {
         new ResearchItem("TINKERSAUGUMENTATION", "ARTIFICE", al, 7, 6, 7, new ItemStack(TinkerTools.titleIcon, 1, 4099))
                 .setPages(new ResearchPage("By using your infusion matrix you were able to add an additional modifier to your TConstruct Tools. Sadly the matrix is only capable of doing this once per tool."),
                         new ResearchPage(Thaumcraft.infusion))
-                .setAutoUnlock();
+                .setAutoUnlock()
                 .registerResearchItem();
     }
 

--- a/src/main/resources/assets/supertic/lang/en_US.lang
+++ b/src/main/resources/assets/supertic/lang/en_US.lang
@@ -1,2 +1,6 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=Spell of the diligent Tinkerer
+
+#Thaumcraft Compat Stuff
+tc.research_name.TINKERSAUGUMENTATION=Thaumic Augmentation
+tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots.

--- a/src/main/resources/assets/supertic/lang/en_US.lang
+++ b/src/main/resources/assets/supertic/lang/en_US.lang
@@ -4,4 +4,4 @@ ritual.SuperTiC_Modifier.name=Spell of the diligent Tinkerer
 #Thaumcraft Compat Stuff
 tc.research_name.TINKERSAUGUMENTATION=Thaumic Augmentation
 tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots.
-STiC=By using your infusion matrix you were able to add an additional modifier to your TConstruct Tools. Sadly the matrix is only capable of doing this once per tool.
+STiC=By using your infusion matrix you were able to add an additional modifier to your Tinker's Construct Tools. Sadly the matrix is only capable of doing this once per tool.

--- a/src/main/resources/assets/supertic/lang/en_US.lang
+++ b/src/main/resources/assets/supertic/lang/en_US.lang
@@ -4,3 +4,4 @@ ritual.SuperTiC_Modifier.name=Spell of the diligent Tinkerer
 #Thaumcraft Compat Stuff
 tc.research_name.TINKERSAUGUMENTATION=Thaumic Augmentation
 tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots.
+STiC=By using your infusion matrix you were able to add an additional modifier to your TConstruct Tools. Sadly the matrix is only capable of doing this once per tool.

--- a/src/main/resources/assets/supertic/lang/en_US.lang
+++ b/src/main/resources/assets/supertic/lang/en_US.lang
@@ -3,5 +3,5 @@ ritual.SuperTiC_Modifier.name=Spell of the diligent Tinkerer
 
 #Thaumcraft Compat Stuff
 tc.research_name.TINKERSAUGUMENTATION=Thaumic Augmentation
-tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots.
+tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots. Fuck you Alastor -Mitch
 STiC=By using your infusion matrix you were able to add an additional modifier to your Tinker's Construct Tools. Sadly the matrix is only capable of doing this once per tool.

--- a/src/main/resources/assets/supertic/lang/en_US.lang
+++ b/src/main/resources/assets/supertic/lang/en_US.lang
@@ -2,6 +2,6 @@
 ritual.SuperTiC_Modifier.name=Spell of the diligent Tinkerer
 
 #Thaumcraft Compat Stuff
-tc.research_name.TINKERSAUGUMENTATION=Thaumic Augmentation
-tc.research_text.TINKERSAUGUMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots. Fuck you Alastor -Mitch
+tc.research_name.TINKERSAUGMENTATION=Thaumic Augmentation
+tc.research_text.TINKERSAUGMENTATION=Are you trying to magically obtain more spell slots? Because that's how you magically obtain more spell slots. Fuck you Alastor -Mitch
 STiC=By using your infusion matrix you were able to add an additional modifier to your Tinker's Construct Tools. Sadly the matrix is only capable of doing this once per tool.

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -2,3 +2,4 @@
 ritual.SuperTiC_Modifier.name=匠魂之咒
 tc.research_name.TINKERSAUGUMENTATION=奇术增强
 tc.research_text.TINKERSAUGUMENTATION=您是否正在尝试神奇地获得更多的法术位？因为这就是你如何神奇地获得更多法术位的方法。
+STiC=通过使用您的矩阵，您可以为您的 Tinker's Construct 工具添加额外的修饰符。可悲的是，每个工具只能执行一次矩阵。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -1,5 +1,5 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=匠魂之咒
-tc.research_name.TINKERSAUGUMENTATION=奇术增强
-tc.research_text.TINKERSAUGUMENTATION=您是否正在尝试神奇地获得更多的法术位？因为这就是你如何神奇地获得更多法术位的方法。
-STiC=通过使用您的矩阵，您可以为您的 Tinker's Construct 工具添加额外的修饰符。可悲的是，每个工具只能执行一次矩阵。
+tc.research_name.TINKERSAUGUMENTATION=泰奥米奇增生术
+tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。
+STiC=通过使用你的输液矩阵，你能够为你的 Tinker's Construct 工具增加一个额外的修改器。遗憾的是，矩阵只能为每个工具做一次。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -1,5 +1,5 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=匠魂之咒
 tc.research_name.TINKERSAUGUMENTATION=泰奥米奇增生术
-tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。
+tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。闭上你的嘴，阿拉斯托尔
 STiC=通过使用你的注魔祭坛，你能够为你的 Tinker's Construct 工具增加一个额外的修正符。遗憾的是，祭坛只能为每个工具做一次。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -2,4 +2,4 @@
 ritual.SuperTiC_Modifier.name=匠魂之咒
 tc.research_name.TINKERSAUGUMENTATION=泰奥米奇增生术
 tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。
-STiC=通过使用你的输液矩阵，你能够为你的 Tinker's Construct 工具增加一个额外的修改器。遗憾的是，矩阵只能为每个工具做一次。
+STiC=通过使用你的注魔祭坛，你能够为你的 Tinker's Construct 工具增加一个额外的修正符。遗憾的是，祭坛只能为每个工具做一次。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -1,5 +1,5 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=匠魂之咒
-tc.research_name.TINKERSAUGUMENTATION=泰奥米奇增生术
-tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。闭上你的嘴，阿拉斯托尔 -Mitch
+tc.research_name.TINKERSAUGMENTATION=泰奥米奇增生术
+tc.research_text.TINKERSAUGMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。闭上你的嘴，阿拉斯托尔 -Mitch
 STiC=通过使用你的注魔祭坛，你能够为你的 Tinker's Construct 工具增加一个额外的修正符。遗憾的是，祭坛只能为每个工具做一次。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -1,2 +1,4 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=匠魂之咒
+tc.research_name.TINKERSAUGUMENTATION=奇术增强
+tc.research_text.TINKERSAUGUMENTATION=您是否正在尝试神奇地获得更多的法术位？因为这就是你如何神奇地获得更多法术位的方法。

--- a/src/main/resources/assets/supertic/lang/zh_CN.lang
+++ b/src/main/resources/assets/supertic/lang/zh_CN.lang
@@ -1,5 +1,5 @@
 #Rituals
 ritual.SuperTiC_Modifier.name=匠魂之咒
 tc.research_name.TINKERSAUGUMENTATION=泰奥米奇增生术
-tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。闭上你的嘴，阿拉斯托尔
+tc.research_text.TINKERSAUGUMENTATION=你是想通过魔法获得更多的法术槽吗？因为这就是你神奇地获得更多法术槽的方法。闭上你的嘴，阿拉斯托尔 -Mitch
 STiC=通过使用你的注魔祭坛，你能够为你的 Tinker's Construct 工具增加一个额外的修正符。遗憾的是，祭坛只能为每个工具做一次。


### PR DESCRIPTION
This currently prevents ichorium from being researched since it is currently not unlockable


I removed it's parents, and set it to automatically unlock, it's not a great fix, but it'll at least make it unlockable.
This is certainly a bandaid fix, I'll see if I can actually fix it later, but for now this should fix the bulk. 
This hasn't been fixed in 4 years, so fixing it at all, no matter the quality is justified.

Likewise, I fixed the localization, so now it'll use both english and chinese, I don't know why they didn't do this from the start, it was a super easy fix.

