### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,9 +11,6 @@
     "authorList": [ "Zokonius" ],
     "credits": "bartimaeusnek, GTNH",
     "logoFile": "",
-    "screenshots": [ "" ],
-    "requiredMods": [ "Forge", "TConstruct" ],
-    "dependencies": [ "TConstruct" , "ExtraTic", "TGregworks", "Thaumcraft", "AWWayofTime"],
-    "useDependencyInformation": true
+    "screenshots": []
   }]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.